### PR TITLE
Ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ banned_ips.json
 examples/*.yarn
 config.json
 docs
+
+# Ignore for webstorm
+/.idea


### PR DESCRIPTION
So I was wanting to checkout to another branch and I saw this annoying folder that webstorm adds and isn't needed for hindenburg.
<img width="641" alt="Screen Shot 2021-09-13 at 16 35 30" src="https://user-images.githubusercontent.com/15304929/133145538-3ebfabd1-5f65-4000-bd7d-aefc38da1ecd.png">
