### PR TITLE
Choose right port

### DIFF
--- a/bin/worker.ts
+++ b/bin/worker.ts
@@ -357,7 +357,7 @@ async function checkConfigDeprecations(config: HindenburgConfig, configFilename:
         worker.logger.warn("Cannot open config file; using default config");
     }
 
-    const port = worker.matchmaker?.port || worker.config.socket.port;
+    const port = worker.config.socket.port || worker.matchmaker?.port as number;
     await worker.listen(port);
 
     worker.logger.info("Listening on:");


### PR DESCRIPTION
Hindenburg chose the matchmaker port for the socket instead of the socket port from the config. This commit fixed that